### PR TITLE
Make Travis CI work on libcreate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+sudo: required
+dist: xenial
+
+language: generic
+
+compiler:
+  - gcc
+
+env:
+  global:
+    - CATKIN_WS=~/catkin_ws
+    - CATKIN_WS_SRC=${CATKIN_WS}/src
+    - CI_ROS_DISTRO="kinetic"
+
+install:
+  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list'
+  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq -y python-rosdep python-catkin-tools
+  - sudo rosdep init
+  - rosdep update
+  # Use rosdep to install all dependencies (including ROS itself)
+  - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
+  - source /opt/ros/$CI_ROS_DISTRO/setup.bash
+  - mkdir -p $CATKIN_WS_SRC
+  # Add the package under integration to the workspace using a symlink
+  - ln -s $TRAVIS_BUILD_DIR $CATKIN_WS_SRC
+
+script:
+  - source /opt/ros/$CI_ROS_DISTRO/setup.bash
+  - cd $CATKIN_WS
+  # Build packages
+  - catkin_make -DCMAKE_BUILD_TYPE=Release
+  # Run the tests, ensuring the path is set correctly.
+  - source devel/setup.bash
+  # Run tests
+  - catkin_make run_tests && catkin_test_results
+  # Lint package files
+  # - sudo apt-get install python-catkin-lint
+  # - catkin lint -W2 --strict --explain src

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,20 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(libcreate)
+## Compile as C++11, supported in ROS Kinetic and newer
+  add_compile_options(-std=c++11)
 
 find_package(catkin REQUIRED)
 find_package(Boost REQUIRED system thread)
 find_package(Threads REQUIRED)
 
 catkin_package(
-  INCLUDE_DIRS include
+  INCLUDE_DIRS include tests
   LIBRARIES create
 )
 
 ## Specify additional locations of header files
 include_directories(
-  include
+  include tests ${catkin_INCLUDE_DIRS}
 )
 
 ## Declare cpp library
@@ -72,3 +74,28 @@ install(TARGETS create
 install(DIRECTORY include/create/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
+
+###########
+# Testing #
+###########
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  include_directories(${GTEST_INCLUDE_DIRS})
+  
+  add_executable(test_create tests/test_create.cpp)
+  add_executable(test_data tests/test_data.cpp)
+  add_executable(test_packet tests/test_packet.cpp)
+  add_executable(test_robot_model tests/test_robot_model.cpp)
+  add_executable(test_serial_query tests/test_serial_query.cpp)
+  add_executable(test_serial_stream tests/test_serial_stream.cpp)
+  
+  target_link_libraries(test_create ${Boost_LIBRARIES} gtest ${catkin_LIBRARIES} create)
+  target_link_libraries(test_data ${Boost_LIBRARIES} gtest ${catkin_LIBRARIES} create)
+  target_link_libraries(test_packet ${Boost_LIBRARIES} gtest ${catkin_LIBRARIES} create)
+  target_link_libraries(test_robot_model ${Boost_LIBRARIES} gtest ${catkin_LIBRARIES} create)
+  target_link_libraries(test_serial_query ${Boost_LIBRARIES} gtest ${catkin_LIBRARIES} create)
+  target_link_libraries(test_serial_stream ${Boost_LIBRARIES} gtest ${catkin_LIBRARIES} create)
+
+  add_rostest(tests/libcreate.test)
+endif()

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ C++ library for interfacing with iRobot's [Create 2](http://www.irobot.com/About
 * Author: [Jacob Perron](http://jacobperron.ca) ([Autonomy Lab](http://autonomylab.org), [Simon Fraser University](http://www.sfu.ca))
 * Contributors: [Mani Monajjemi](http:mani.im), [Ben Wolsieffer](https://github.com/lopsided98)
 
+## Build status ##
+
+![Build Status](https://api.travis-ci.org/RoboticaUtnFrba/libcreate.svg?branch=master)
+
 ## Dependencies ##
 
 * [Boost System Library](http://www.boost.org/doc/libs/1_59_0/libs/system/doc/index.html)

--- a/package.xml
+++ b/package.xml
@@ -9,10 +9,16 @@
   <license>BSD</license>
 
   <url type="website">http://wiki.ros.org/libcreate</url>
-  
+
   <author email="jperron@sfu.ca">Jacob Perron</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>boost</depend>
+
+  <test_depend>gtest</test_depend>
+  <test_depend>rostest</test_depend>
+  <test_depend>rosunit</test_depend>
 
   <export>
   </export>

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -326,10 +326,10 @@ namespace create {
     }
 
     uint8_t cmd[5] = { OC_DRIVE,
-                       vel_mm >> 8,
-                       vel_mm & 0xff,
-                       radius_mm >> 8,
-                       radius_mm & 0xff
+                       static_cast<uint8_t>(vel_mm >> 8),
+                       static_cast<uint8_t>(vel_mm & 0xff),
+                       static_cast<uint8_t>(radius_mm >> 8),
+                       static_cast<uint8_t>(radius_mm & 0xff)
                      };
 
     return serial->send(cmd, 5);
@@ -345,10 +345,10 @@ namespace create {
       int16_t rightCmd = roundf(boundedRightVel * 1000);
 
       uint8_t cmd[5] = { OC_DRIVE_DIRECT,
-                         rightCmd >> 8,
-                         rightCmd & 0xff,
-                         leftCmd >> 8,
-                         leftCmd & 0xff
+                         static_cast<uint8_t>(rightCmd >> 8),
+                         static_cast<uint8_t>(rightCmd & 0xff),
+                         static_cast<uint8_t>(leftCmd >> 8),
+                         static_cast<uint8_t>(leftCmd & 0xff)
                        };
       return serial->send(cmd, 5);
     } else {

--- a/tests/libcreate.test
+++ b/tests/libcreate.test
@@ -1,0 +1,8 @@
+<launch> 
+  <test test-name="test_create" pkg="libcreate" type="test_create" name="test_create" />
+  <test test-name="test_data" pkg="libcreate" type="test_data" name="test_data" />
+  <test test-name="test_packet" pkg="libcreate" type="test_packet" name="test_packet" />
+  <test test-name="test_robot_model" pkg="libcreate" type="test_robot_model" name="test_robot_model" />
+  <test test-name="test_serial_query" pkg="libcreate" type="test_serial_query" name="test_serial_query" />
+  <test test-name="test_serial_stream" pkg="libcreate" type="test_serial_stream" name="test_serial_stream" />
+</launch>

--- a/tests/test_create.cpp
+++ b/tests/test_create.cpp
@@ -1,0 +1,70 @@
+/**
+Software License Agreement (BSD)
+\file      test_create.cpp
+\authors   Jacob Perron <jperron@sfu.ca>
+\copyright Copyright (c) 2018, Autonomy Lab (Simon Fraser University), All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Autonomy Lab nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "create/create.h"
+#include "create/types.h"
+
+#include "gtest/gtest.h"
+
+#include <boost/shared_ptr.hpp>
+
+TEST(CreateTest, ConstructorSingleParam)
+{
+  create::Create create_default;
+
+  create::Create create_1(create::RobotModel::CREATE_1);
+
+  create::Create create_2(create::RobotModel::CREATE_2);
+
+  create::Create create_roomba_400(create::RobotModel::ROOMBA_400);
+}
+
+// TEST(CreateTest, ConstructorMultiParam)
+// {
+//   TODO(jacobperron): Document exception thrown and consider defining custom exception
+//   create::Create create(std::string("/dev/ttyUSB0"), 11520);
+// }
+
+TEST(CreateTest, Connected)
+{
+  create::Create create;
+  // Nothing to be connected to
+  EXPECT_FALSE(create.connected());
+}
+
+TEST(CreateTest, Disconnect)
+{
+  create::Create create;
+  // Even though not connected, this should not crash
+  create.disconnect();
+}
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/test_data.cpp
+++ b/tests/test_data.cpp
@@ -1,0 +1,175 @@
+/**
+Software License Agreement (BSD)
+
+\file      test_data.cpp
+\authors   Jacob Perron <jperron@sfu.ca>
+\copyright Copyright (c) 2018, Autonomy Lab (Simon Fraser University), All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Autonomy Lab nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "create/data.h"
+#include "create/packet.h"
+#include "create/types.h"
+
+#include "gtest/gtest.h"
+
+#include <boost/shared_ptr.hpp>
+
+TEST(DataTest, Constructor)
+{
+  create::Data data_default;
+
+  create::Data data_v_1(create::V_1);
+
+  create::Data data_v_2(create::V_2);
+
+  create::Data data_v_3(create::V_3);
+
+  create::Data data_v_all(create::V_ALL);
+}
+
+// Number of packets for a given protocol are determined in the Data() constructor
+TEST(DataTest, GetNumPackets)
+{
+  // Number of packets shared by all protocols is 16
+  create::Data data_v_1(create::V_1);
+  // Number exclusive to V_1 = 4
+  // 16 + 4 = 20
+  EXPECT_EQ(static_cast<int>(data_v_1.getNumPackets()), 20);
+
+  create::Data data_v_2(create::V_2);
+  // Number exclusive to V_2 = 3
+  // 16 + 3 = 19
+  EXPECT_EQ(static_cast<int>(data_v_2.getNumPackets()), 19);
+
+  create::Data data_v_3(create::V_3);
+  // Number exclusive to V_3 = 14
+  // 16 + 14 = 30
+  EXPECT_EQ(static_cast<int>(data_v_3.getNumPackets()), 30);
+
+  create::Data data_v_all(create::V_ALL);
+  EXPECT_EQ(static_cast<int>(data_v_all.getNumPackets()), 33);
+}
+
+TEST(DataTest, GetPacket)
+{
+  // Get a packet exclusive to V_1
+  create::Data data_v_1(create::V_1);
+  boost::shared_ptr<create::Packet> v_1_packet_ptr = data_v_1.getPacket(create::ID_OVERCURRENTS);
+  EXPECT_NE(v_1_packet_ptr, boost::shared_ptr<create::Packet>())
+      << "ID_OVERCURRENTS packet not found for protocol V_1";
+  EXPECT_EQ(static_cast<int>(v_1_packet_ptr->nbytes), 1);
+  EXPECT_EQ(v_1_packet_ptr->info, std::string("overcurrents"));
+
+  // Get a packet for V_2
+  create::Data data_v_2(create::V_2);
+  boost::shared_ptr<create::Packet> v_2_packet_ptr = data_v_2.getPacket(create::ID_DISTANCE);
+  EXPECT_NE(v_2_packet_ptr, boost::shared_ptr<create::Packet>())
+      << "ID_DISTANCE packet not found for protocol V_2";
+  EXPECT_EQ(static_cast<int>(v_2_packet_ptr->nbytes), 2);
+  EXPECT_EQ(v_2_packet_ptr->info, std::string("distance"));
+
+  // Get a packet exclusive to V_3
+  create::Data data_v_3(create::V_3);
+  boost::shared_ptr<create::Packet> v_3_packet_ptr = data_v_3.getPacket(create::ID_LIGHT_FRONT_RIGHT);
+  EXPECT_NE(v_3_packet_ptr, boost::shared_ptr<create::Packet>())
+      << "ID_LIGHT_FRONT_RIGHT packet not found for protocol V_3";
+  EXPECT_EQ(static_cast<int>(v_3_packet_ptr->nbytes), 2);
+  EXPECT_EQ(v_3_packet_ptr->info, std::string("light_bumper_front_right"));
+
+  // Get a non-existent packet
+  boost::shared_ptr<create::Packet> not_a_packet_ptr = data_v_3.getPacket(60);
+  EXPECT_EQ(not_a_packet_ptr, boost::shared_ptr<create::Packet>());
+}
+
+TEST(DataTest, GetPacketIDs)
+{
+  create::Data data_v_3(create::V_3);
+  const std::vector<uint8_t> packet_ids = data_v_3.getPacketIDs();
+  // Vector should have same length as reported by getNumPackets()
+  ASSERT_EQ(static_cast<int>(packet_ids.size()), 30);
+
+  // Vector should contain ID_LEFT_ENC
+  bool found = false;
+  for (std::size_t i = 0; (i < packet_ids.size()) && !found; i++)
+  {
+    if (packet_ids[i] == create::ID_LEFT_ENC)
+    {
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found) << "ID_LEFT_ENC packet ID not returned for protocol V_3";
+}
+
+TEST(DataTest, GetTotalDataBytes)
+{
+  // All protocols have 20 mutual data bytes
+  // V_1 has an additional 6 bytes
+  create::Data data_v_1(create::V_1);
+  EXPECT_EQ(static_cast<int>(data_v_1.getTotalDataBytes()), 26);
+
+  // V_2 has an additional 5 bytes
+  create::Data data_v_2(create::V_2);
+  EXPECT_EQ(static_cast<int>(data_v_2.getTotalDataBytes()), 25);
+
+  // V_3 has an additional 23 bytes
+  create::Data data_v_3(create::V_3);
+  EXPECT_EQ(static_cast<int>(data_v_3.getTotalDataBytes()), 43);
+}
+
+TEST(DataTest, IsValidPacketID)
+{
+  create::Data data_v_1(create::V_1);
+  EXPECT_TRUE(data_v_1.isValidPacketID(create::ID_DIRT_DETECT_RIGHT))
+      << "ID_DIRT_DETECT_RIGHT packet not found for protocol V_1";
+  EXPECT_FALSE(data_v_1.isValidPacketID(create::ID_OI_MODE))
+      << "ID_OI_MODE packet should not exist for protocol V_1";
+
+  // V_2 has an additional 5 bytes
+  create::Data data_v_2(create::V_2);
+  EXPECT_TRUE(data_v_2.isValidPacketID(create::ID_ANGLE))
+      << "ID_ANGLE packet not found for protocol V_2";
+  EXPECT_FALSE(data_v_2.isValidPacketID(create::ID_LIGHT))
+      << "ID_LIGHT packet should not exist for protocol V_2";
+
+  // V_3 has an additional 21 bytes
+  create::Data data_v_3(create::V_3);
+  EXPECT_TRUE(data_v_3.isValidPacketID(create::ID_STASIS))
+      << "ID_STATIS packet not found for protocol V_3";
+  EXPECT_FALSE(data_v_3.isValidPacketID(create::ID_DISTANCE))
+      << "ID_DISTANCE packet should not exist for protocol V_3";
+}
+
+TEST(DataTest, ValidateAll)
+{
+  create::Data data_v_3(create::V_3);
+  // Don't crash
+  data_v_3.validateAll();
+}
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/test_packet.cpp
+++ b/tests/test_packet.cpp
@@ -1,0 +1,79 @@
+/**
+Software License Agreement (BSD)
+
+\file      test_packet.cpp
+\authors   Jacob Perron <jperron@sfu.ca>
+\copyright Copyright (c) 2018, Autonomy Lab (Simon Fraser University), All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Autonomy Lab nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "create/packet.h"
+#include "create/types.h"
+
+#include "gtest/gtest.h"
+
+TEST(PacketTest, Constructor)
+{
+  create::Packet empty_packet(0, std::string(""));
+  EXPECT_EQ(static_cast<int>(empty_packet.nbytes), 0);
+  EXPECT_EQ(empty_packet.info, std::string(""));
+
+  create::Packet some_packet(2, std::string("test_packet"));
+  EXPECT_EQ(static_cast<int>(some_packet.nbytes), 2);
+  EXPECT_EQ(some_packet.info, std::string("test_packet"));
+}
+
+TEST(PacketTest, SetValidateAndGetData)
+{
+  create::Packet packet(2, std::string("test_packet"));
+
+  // Set some data and validate it
+  const uint16_t some_data = 123;
+  packet.setTempData(some_data);
+  packet.validate();
+  // Confirm data was validated
+  const uint16_t some_data_result = packet.getData();
+  EXPECT_EQ(some_data_result, some_data);
+
+  // Set zero data and validate it
+  const uint16_t zero_data = 0;
+  packet.setTempData(zero_data);
+  packet.validate();
+  // Confirm data was validated
+  const uint16_t zero_data_result = packet.getData();
+  EXPECT_EQ(zero_data_result, zero_data);
+
+  // Set some data but do not validate it
+  const uint16_t do_not_validate_data = 321;
+  packet.setTempData(do_not_validate_data);
+  // Confirm data was not validated
+  const uint16_t unvalidated_data_result = packet.getData();
+  EXPECT_NE(unvalidated_data_result, do_not_validate_data);
+}
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/test_robot_model.cpp
+++ b/tests/test_robot_model.cpp
@@ -1,0 +1,49 @@
+/**
+Software License Agreement (BSD)
+
+\file      test_robot_model.cpp
+\authors   Jacob Perron <jperron@sfu.ca>
+\copyright Copyright (c) 2018, Autonomy Lab (Simon Fraser University), All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Autonomy Lab nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "create/types.h"
+
+#include "gtest/gtest.h"
+
+TEST(RobotModelTest, Equality)
+{
+  EXPECT_EQ(create::RobotModel::CREATE_1, create::RobotModel::CREATE_1);
+  EXPECT_EQ(create::RobotModel::CREATE_2, create::RobotModel::CREATE_2);
+  EXPECT_EQ(create::RobotModel::ROOMBA_400, create::RobotModel::ROOMBA_400);
+  EXPECT_NE(create::RobotModel::CREATE_1, create::RobotModel::CREATE_2);
+  EXPECT_NE(create::RobotModel::CREATE_1, create::RobotModel::ROOMBA_400);
+  EXPECT_NE(create::RobotModel::CREATE_2, create::RobotModel::ROOMBA_400);
+}
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/test_serial_query.cpp
+++ b/tests/test_serial_query.cpp
@@ -1,0 +1,96 @@
+/**
+Software License Agreement (BSD)
+
+\file      test_serial_query.cpp
+\authors   Jacob Perron <jperron@sfu.ca>
+\copyright Copyright (c) 2018, Autonomy Lab (Simon Fraser University), All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Autonomy Lab nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "create/data.h"
+#include "create/serial_query.h"
+
+#include "gtest/gtest.h"
+
+#include <boost/shared_ptr.hpp>
+
+TEST(SerialQueryTest, Constructor)
+{
+  boost::shared_ptr<create::Data> data_ptr = boost::make_shared<create::Data>();
+  create::SerialQuery serial_query(data_ptr);
+}
+
+TEST(SerialQueryTest, Connected)
+{
+  boost::shared_ptr<create::Data> data_ptr = boost::make_shared<create::Data>();
+  create::SerialQuery serial_query(data_ptr);
+
+  // Did not call connect and nothing to connect to, so expect false
+  EXPECT_FALSE(serial_query.connected());
+}
+
+TEST(SerialQueryTest, Disconnect)
+{
+  boost::shared_ptr<create::Data> data_ptr = boost::make_shared<create::Data>();
+  create::SerialQuery serial_query(data_ptr);
+
+  // Not connected, but should not fail
+  serial_query.disconnect();
+}
+
+TEST(SerialQueryTest, NumPackets)
+{
+  boost::shared_ptr<create::Data> data_ptr = boost::make_shared<create::Data>();
+  create::SerialQuery serial_query(data_ptr);
+
+  // Not connected, so zero packets should have been received
+  EXPECT_EQ(serial_query.getNumCorruptPackets(), 0);
+  EXPECT_EQ(serial_query.getTotalPackets(), 0);
+}
+
+TEST(SerialQueryTest, Send)
+{
+  boost::shared_ptr<create::Data> data_ptr = boost::make_shared<create::Data>();
+  create::SerialQuery serial_query(data_ptr);
+
+  // Some bytes to send (to set date)
+  uint8_t bytes[4] = { create::OC_DATE, 0, 1, 2 };
+  // Not connected, so failure expected
+  EXPECT_FALSE(serial_query.send(bytes, 4));
+}
+
+TEST(SerialQueryTest, SendOpcode)
+{
+  boost::shared_ptr<create::Data> data_ptr = boost::make_shared<create::Data>();
+  create::SerialQuery serial_query(data_ptr);
+
+  // Not connected, so failure expected
+  EXPECT_FALSE(serial_query.sendOpcode(create::OC_POWER));
+}
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/test_serial_stream.cpp
+++ b/tests/test_serial_stream.cpp
@@ -1,0 +1,96 @@
+/**
+Software License Agreement (BSD)
+
+\file      test_serial_stream.cpp
+\authors   Jacob Perron <jperron@sfu.ca>
+\copyright Copyright (c) 2018, Autonomy Lab (Simon Fraser University), All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Autonomy Lab nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "create/data.h"
+#include "create/serial_stream.h"
+
+#include "gtest/gtest.h"
+
+#include <boost/shared_ptr.hpp>
+
+TEST(SerialStreamTest, Constructor)
+{
+  boost::shared_ptr<create::Data> data_ptr = boost::make_shared<create::Data>();
+  create::SerialStream serial_stream(data_ptr);
+}
+
+TEST(SerialStreamTest, Connected)
+{
+  boost::shared_ptr<create::Data> data_ptr = boost::make_shared<create::Data>();
+  create::SerialStream serial_stream(data_ptr);
+
+  // Did not call connect and nothing to connect to, so expect false
+  EXPECT_FALSE(serial_stream.connected());
+}
+
+TEST(SerialStreamTest, Disconnect)
+{
+  boost::shared_ptr<create::Data> data_ptr = boost::make_shared<create::Data>();
+  create::SerialStream serial_stream(data_ptr);
+
+  // Not connected, but should not fail
+  serial_stream.disconnect();
+}
+
+TEST(SerialStreamTest, NumPackets)
+{
+  boost::shared_ptr<create::Data> data_ptr = boost::make_shared<create::Data>();
+  create::SerialStream serial_stream(data_ptr);
+
+  // Not connected, so zero packets should have been received
+  EXPECT_EQ(serial_stream.getNumCorruptPackets(), 0);
+  EXPECT_EQ(serial_stream.getTotalPackets(), 0);
+}
+
+TEST(SerialStreamTest, Send)
+{
+  boost::shared_ptr<create::Data> data_ptr = boost::make_shared<create::Data>();
+  create::SerialStream serial_stream(data_ptr);
+
+  // Some bytes to send (to set date)
+  uint8_t bytes[4] = { create::OC_DATE, 0, 1, 2 };
+  // Not connected, so failure expected
+  EXPECT_FALSE(serial_stream.send(bytes, 4));
+}
+
+TEST(SerialStreamTest, SendOpcode)
+{
+  boost::shared_ptr<create::Data> data_ptr = boost::make_shared<create::Data>();
+  create::SerialStream serial_stream(data_ptr);
+
+  // Not connected, so failure expected
+  EXPECT_FALSE(serial_stream.sendOpcode(create::OC_POWER));
+}
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This PR activates again Travis CI for this package.

**TODO:** use `catkin lint` and block PRs until they pass the tests.